### PR TITLE
Changes in restrict and in_interval

### DIFF
--- a/neuroseries/interval_set.py
+++ b/neuroseries/interval_set.py
@@ -200,7 +200,7 @@ class IntervalSet(pd.DataFrame):
         IntervalSet.
         """
         bins = self.values.ravel()
-        ix = np.array(pd.cut(tsd.index, bins, labels=np.arange(len(bins) - 1, dtype=np.int64)))
+        ix = np.array(pd.cut(tsd.index, bins, labels=np.arange(len(bins) - 1, dtype=np.float64)))
         ix[np.floor(ix / 2) * 2 != ix] = np.NaN
         ix = np.floor(ix/2)
         return ix

--- a/neuroseries/time_series.py
+++ b/neuroseries/time_series.py
@@ -282,7 +282,7 @@ class Tsd(pd.Series):
         ix = ~np.isnan(ix)
         tsd_r = tsd_r[ix]
         if not keep_labels:
-            s = tsd_r.iloc[:, col]
+            s = tsd_r.iloc[:,0]
             return Tsd(s)
         return Tsd(tsd_r, copy=True)
 


### PR DESCRIPTION
Hello
The first change is the same as the issue I opened.
The second change is because in restrict, .iloc doesn't accept anything else than an int.
For exemple if I have a TsdFrame such as:
```python
frame = nts.TsdFrame(t = times, d = data, columns = ['angle', 'xpos', 'ypos'])
```
and I cut it to take only the angle:
```python
angle = frame['angle']
```
and try to restrict it:
```python
angle.restrict(epoch)
```
in restrict:
```python
s = tsd_r.iloc[:, col]
```
will bug because col is 'angle' and not 0.
Since Tsd is a one dimensional dataset, it can be assumed it's always the first column.

Best 

Guillaume